### PR TITLE
Add Ranged & SignedNumberGenerator for Byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * SelectorGenerator
+* Ranged- and SignedNumberGenerator for:
+    - Byte
 
 ### Changed
+
+* iterable of fixture is now called option
 
 ### Deprecated
 

--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -69,6 +69,21 @@ public abstract interface class tech/antibytes/kfixture/PublicApi$Qualifier {
 	public abstract fun getValue ()Ljava/lang/String;
 }
 
+public abstract interface class tech/antibytes/kfixture/PublicApi$RangedGenerator : tech/antibytes/kfixture/PublicApi$Generator {
+	public abstract fun generate (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class tech/antibytes/kfixture/PublicApi$Sign : java/lang/Enum {
+	public static final field NEGATIVE Ltech/antibytes/kfixture/PublicApi$Sign;
+	public static final field POSITIVE Ltech/antibytes/kfixture/PublicApi$Sign;
+	public static fun valueOf (Ljava/lang/String;)Ltech/antibytes/kfixture/PublicApi$Sign;
+	public static fun values ()[Ltech/antibytes/kfixture/PublicApi$Sign;
+}
+
+public abstract interface class tech/antibytes/kfixture/PublicApi$SignedNumberGenerator : tech/antibytes/kfixture/PublicApi$RangedGenerator {
+	public abstract fun generate (Ltech/antibytes/kfixture/PublicApi$Sign;)Ljava/lang/Object;
+}
+
 public final class tech/antibytes/kfixture/generator/selector/SelectorGeneratorFactory : tech/antibytes/kfixture/PublicApi$GeneratorFactory {
 	public fun <init> ([Ljava/lang/Object;)V
 	public fun getInstance (Lkotlin/random/Random;)Ltech/antibytes/kfixture/PublicApi$Generator;

--- a/core/api/jvm/core.api
+++ b/core/api/jvm/core.api
@@ -62,6 +62,21 @@ public abstract interface class tech/antibytes/kfixture/PublicApi$Qualifier {
 	public abstract fun getValue ()Ljava/lang/String;
 }
 
+public abstract interface class tech/antibytes/kfixture/PublicApi$RangedGenerator : tech/antibytes/kfixture/PublicApi$Generator {
+	public abstract fun generate (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class tech/antibytes/kfixture/PublicApi$Sign : java/lang/Enum {
+	public static final field NEGATIVE Ltech/antibytes/kfixture/PublicApi$Sign;
+	public static final field POSITIVE Ltech/antibytes/kfixture/PublicApi$Sign;
+	public static fun valueOf (Ljava/lang/String;)Ltech/antibytes/kfixture/PublicApi$Sign;
+	public static fun values ()[Ltech/antibytes/kfixture/PublicApi$Sign;
+}
+
+public abstract interface class tech/antibytes/kfixture/PublicApi$SignedNumberGenerator : tech/antibytes/kfixture/PublicApi$RangedGenerator {
+	public abstract fun generate (Ltech/antibytes/kfixture/PublicApi$Sign;)Ljava/lang/Object;
+}
+
 public final class tech/antibytes/kfixture/generator/selector/SelectorGeneratorFactory : tech/antibytes/kfixture/PublicApi$GeneratorFactory {
 	public fun <init> ([Ljava/lang/Object;)V
 	public fun getInstance (Lkotlin/random/Random;)Ltech/antibytes/kfixture/PublicApi$Generator;

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -60,9 +60,16 @@ antiBytesCoverage {
         minimum = BigDecimal(0.97)
     )
 
+    val excludes = setOf(
+        "**/FixtureKt*",
+        "**/RangedFixtureKt*",
+        "**/SignedNumericFixtureKt*",
+        "**/BindingKt*",
+    ) // Inline Function cannot be covered
+
     val jvmCoverage = JvmJacocoConfiguration.createJvmKmpConfiguration(
         project,
-        classFilter = setOf("**/FixtureKt*"), // Inline Function cannot be covered
+        classFilter = excludes,
         verificationRules = setOf(
             branchCoverage,
             instructionCoverage
@@ -71,7 +78,7 @@ antiBytesCoverage {
 
     val androidCoverage = AndroidJacocoConfiguration.createAndroidLibraryKmpConfiguration(
         project,
-        classFilter = setOf("**/FixtureKt*"), // Inline Function cannot be covered
+        classFilter = excludes, // Inline Function cannot be covered
         verificationRules = setOf(
             branchCoverage,
             instructionCoverage

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/Fixture.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/Fixture.kt
@@ -110,12 +110,10 @@ internal inline fun <reified T> PublicApi.Fixture.resolveIdentifier(
 /**
  * Picks an value from a given Iterable.
  * @param T the type which is supposed to be created.
- * @param iterable - an iterable with values where to pick from.
+ * @param options - an iterable with values where to pick from.
  */
-public fun <T> PublicApi.Fixture.fixture(
-    iterable: Iterable<T>,
-): T {
-    val values = iterable.toList()
+public fun <T> PublicApi.Fixture.fixture(options: Iterable<T>): T {
+    val values = options.toList()
 
     return values[pickAnListIndex(values)]
 }
@@ -126,6 +124,7 @@ public fun <T> PublicApi.Fixture.fixture(
  * @param qualifier a optional qualifier for a special flavour of a type.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.fixture(
     qualifier: PublicApi.Qualifier? = null,
 ): T {
@@ -146,6 +145,7 @@ public inline fun <reified T> PublicApi.Fixture.fixture(
  * @param size the size of the List.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.mutableListFixture(
     qualifier: PublicApi.Qualifier? = null,
     size: Int? = null,
@@ -168,6 +168,7 @@ public inline fun <reified T> PublicApi.Fixture.mutableListFixture(
  * @param size the size of the List.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : MutableList<T>, reified T> PublicApi.Fixture.fixture(
     type: KClass<MutableList<*>>,
     qualifier: PublicApi.Qualifier? = null,
@@ -184,6 +185,7 @@ public inline fun <reified C : MutableList<T>, reified T> PublicApi.Fixture.fixt
  * @param size the size of the List.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.listFixture(
     qualifier: PublicApi.Qualifier? = null,
     size: Int? = null,
@@ -203,6 +205,7 @@ public inline fun <reified T> PublicApi.Fixture.listFixture(
  * @param size the size of the List.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : List<T>, reified T> PublicApi.Fixture.fixture(
     type: KClass<List<*>>,
     qualifier: PublicApi.Qualifier? = null,
@@ -219,6 +222,7 @@ public inline fun <reified C : List<T>, reified T> PublicApi.Fixture.fixture(
  * @param size the size of the Collection.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.mutableCollectionFixture(
     qualifier: PublicApi.Qualifier? = null,
     size: Int? = null,
@@ -238,6 +242,7 @@ public inline fun <reified T> PublicApi.Fixture.mutableCollectionFixture(
  * @param size the size of the Collection.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : MutableCollection<T>, reified T> PublicApi.Fixture.fixture(
     type: KClass<MutableCollection<*>>,
     qualifier: PublicApi.Qualifier? = null,
@@ -254,6 +259,7 @@ public inline fun <reified C : MutableCollection<T>, reified T> PublicApi.Fixtur
  * @param size the size of the Collection.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.collectionFixture(
     qualifier: PublicApi.Qualifier? = null,
     size: Int? = null,
@@ -273,6 +279,7 @@ public inline fun <reified T> PublicApi.Fixture.collectionFixture(
  * @param size the size of the Collection.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : Collection<T>, reified T> PublicApi.Fixture.fixture(
     type: KClass<Collection<*>>,
     qualifier: PublicApi.Qualifier? = null,
@@ -289,6 +296,7 @@ public inline fun <reified C : Collection<T>, reified T> PublicApi.Fixture.fixtu
  * @param size the size of the Array.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.arrayFixture(
     qualifier: PublicApi.Qualifier? = null,
     size: Int? = null,
@@ -307,6 +315,7 @@ public inline fun <reified T> PublicApi.Fixture.arrayFixture(
  * @param size the size of the Array.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.fixture(
     type: KClass<Array<*>>,
     qualifier: PublicApi.Qualifier? = null,
@@ -323,6 +332,7 @@ public inline fun <reified T> PublicApi.Fixture.fixture(
  * @param size the size of the Sequence.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.sequenceFixture(
     qualifier: PublicApi.Qualifier? = null,
     size: Int? = null,
@@ -347,6 +357,7 @@ public inline fun <reified T> PublicApi.Fixture.sequenceFixture(
  * @param size the size of the Sequence.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : Sequence<T>, reified T> PublicApi.Fixture.fixture(
     type: KClass<Sequence<*>>,
     qualifier: PublicApi.Qualifier? = null,
@@ -364,6 +375,7 @@ public inline fun <reified C : Sequence<T>, reified T> PublicApi.Fixture.fixture
  * @param secondQualifier - a optional qualifier for a special flavour of a type of the second value.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified First, reified Second> PublicApi.Fixture.pairFixture(
     firstQualifier: PublicApi.Qualifier? = null,
     secondQualifier: PublicApi.Qualifier? = null,
@@ -381,6 +393,7 @@ public inline fun <reified First, reified Second> PublicApi.Fixture.pairFixture(
  * @param secondQualifier - a optional qualifier for a special flavour of a type of the second value.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : Pair<First, Second>, reified First, reified Second> PublicApi.Fixture.fixture(
     type: KClass<Pair<*, *>>,
     firstQualifier: PublicApi.Qualifier? = null,
@@ -400,6 +413,7 @@ public inline fun <reified C : Pair<First, Second>, reified First, reified Secon
  * @param thirdQualifier a optional qualifier for a special flavour of a type of the third value.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified First, reified Second, reified Third> PublicApi.Fixture.tripleFixture(
     firstQualifier: PublicApi.Qualifier? = null,
     secondQualifier: PublicApi.Qualifier? = null,
@@ -426,6 +440,7 @@ public inline fun <reified First, reified Second, reified Third> PublicApi.Fixtu
  * @param thirdQualifier a optional qualifier for a special flavour of a type of the third value.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : Triple<First, Second, Third>, reified First, reified Second, reified Third> PublicApi.Fixture.fixture(
     type: KClass<Triple<*, *, *>>,
     firstQualifier: PublicApi.Qualifier? = null,
@@ -446,6 +461,7 @@ public inline fun <reified C : Triple<First, Second, Third>, reified First, reif
  * @param size the size of the Map.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified Key, reified Value> PublicApi.Fixture.mapFixture(
     keyQualifier: PublicApi.Qualifier? = null,
     valueQualifier: PublicApi.Qualifier? = null,
@@ -471,6 +487,7 @@ public inline fun <reified Key, reified Value> PublicApi.Fixture.mapFixture(
  * @param size the size of the Map.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : Map<Key, Value>, reified Key, reified Value> PublicApi.Fixture.fixture(
     type: KClass<Map<*, *>>,
     keyQualifier: PublicApi.Qualifier? = null,
@@ -491,6 +508,7 @@ public inline fun <reified C : Map<Key, Value>, reified Key, reified Value> Publ
  * @param size the size of the Map.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified Key, reified Value> PublicApi.Fixture.mutableMapFixture(
     keyQualifier: PublicApi.Qualifier? = null,
     valueQualifier: PublicApi.Qualifier? = null,
@@ -514,6 +532,7 @@ public inline fun <reified Key, reified Value> PublicApi.Fixture.mutableMapFixtu
  * @param size the size of the Map.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : MutableMap<Key, Value>, reified Key, reified Value> PublicApi.Fixture.fixture(
     type: KClass<MutableMap<*, *>>,
     keyQualifier: PublicApi.Qualifier? = null,
@@ -532,6 +551,7 @@ public inline fun <reified C : MutableMap<Key, Value>, reified Key, reified Valu
  * @param size the size of the Set.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.mutableSetFixture(
     qualifier: PublicApi.Qualifier? = null,
     size: Int? = null,
@@ -558,6 +578,7 @@ public inline fun <reified T> PublicApi.Fixture.mutableSetFixture(
  * @param size the size of the Set.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : MutableSet<T>, reified T> PublicApi.Fixture.fixture(
     type: KClass<MutableSet<*>>,
     qualifier: PublicApi.Qualifier? = null,
@@ -574,6 +595,7 @@ public inline fun <reified C : MutableSet<T>, reified T> PublicApi.Fixture.fixtu
  * @param size the size of the Set.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified T> PublicApi.Fixture.setFixture(
     qualifier: PublicApi.Qualifier? = null,
     size: Int? = null,
@@ -590,6 +612,7 @@ public inline fun <reified T> PublicApi.Fixture.setFixture(
  * @param size the size of the Set.
  * @throws IllegalStateException if the no matching Generator was found for the given type.
  */
+@Throws(IllegalStateException::class)
 public inline fun <reified C : Set<T>, reified T> PublicApi.Fixture.fixture(
     type: KClass<Set<*>>,
     qualifier: PublicApi.Qualifier? = null,

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/PublicApi.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/PublicApi.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
  */
 public interface PublicApi {
     /**
-     * Generator of value for specific type.
+     * Generator of values for specific type.
      * @param T the type which the Generator is referring to.
      * @author Matthias Geisler
      */
@@ -25,6 +25,48 @@ public interface PublicApi {
          * @return a instance of a given type.
          */
         public fun generate(): T
+    }
+
+    /**
+     * Generator of values for specific type in a given Range.
+     * @param T the type which the Generator is referring to.
+     * @author Matthias Geisler
+     */
+    public interface RangedGenerator<T> : Generator<T> where T : Any, T : Comparable<T> {
+
+        /**
+         * Generates a instance of given type in a given range.
+         * @param from the lower boundary of the value.
+         * @param to the upper boundary of the value.
+         * @throws IllegalArgumentException if start value is greater than the end value.
+         * @return a instance of a given type.
+         */
+        @Throws(IllegalArgumentException::class)
+        public fun generate(
+            from: T,
+            to: T,
+        ): T
+    }
+
+    /**
+     * Indicator if the a numeric type should be resoled as positive or negative Number.
+     */
+    public enum class Sign {
+        POSITIVE,
+        NEGATIVE,
+    }
+
+    /**
+     * Generator of values for specific type in a given Range of signed Numbers.
+     * @param T the type which the Generator is referring to.
+     * @author Matthias Geisler
+     */
+    public interface SignedNumberGenerator<T> : RangedGenerator<T> where T : Any, T : Comparable<T> {
+        /**
+         * Generates a instance of given type in a given range.
+         * @return a instance of a given type.
+         */
+        public fun generate(sign: Sign): T
     }
 
     /**

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/RangedFixture.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/RangedFixture.kt
@@ -1,0 +1,58 @@
+/* ktlint-disable filename */
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kfixture
+
+@Throws(IllegalStateException::class)
+/**
+ * Creates a value for a given type in given boundaries, excluding generics like List or Array.
+ * @param FixtureType the type which is supposed to be created.
+ * @param RangeType the type which is supposed to be created and is bounded to its boundaries.
+ * @param from the lower boundary of the value.
+ * @param to the upper boundary of the value.
+ * @param qualifier a optional qualifier for a special flavour of a type.
+ * @throws IllegalStateException if the no matching Generator was found for the given type.
+ */
+public inline fun <reified RangeType, reified FixtureType : RangeType?> PublicApi.Fixture.fixture(
+    from: RangeType & Any,
+    to: RangeType & Any,
+    qualifier: PublicApi.Qualifier? = null,
+): FixtureType {
+    val returnNull = random.returnNull<FixtureType>()
+    val id = resolveIdentifier<FixtureType>(qualifier)
+    val generator = generators[id]
+
+    @Suppress("UNCHECKED_CAST")
+    return when {
+        generator !is PublicApi.RangedGenerator<*> -> {
+            throw IllegalStateException("Missing Generator for ClassID ($id).")
+        }
+        returnNull -> null as FixtureType
+        else -> (generator as PublicApi.RangedGenerator<Comparable<Any>>).generate(
+            from = from as Comparable<Any>,
+            to = to as Comparable<Any>,
+        ) as FixtureType
+    }
+}
+
+@Throws(IllegalStateException::class)
+/**
+ * Creates a value for a given type in a given range, excluding generics like List or Array.
+ * @param FixtureType the type which is supposed to be created.
+ * @param RangeType the type which is supposed to be created and is bounded to its boundaries.
+ * @param range the lower boundary of the value.
+ * @param qualifier a optional qualifier for a special flavour of a type.
+ * @throws IllegalStateException if the no matching Generator was found for the given type.
+ */
+public inline fun <reified RangeType, reified FixtureType : RangeType?> PublicApi.Fixture.fixture(
+    range: ClosedRange<RangeType>,
+    qualifier: PublicApi.Qualifier? = null,
+): FixtureType where RangeType : Comparable<RangeType> = fixture(
+    from = range.start,
+    to = range.endInclusive,
+    qualifier = qualifier,
+)

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/SignedNumericFixture.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/SignedNumericFixture.kt
@@ -1,0 +1,34 @@
+/* ktlint-disable filename */
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kfixture
+
+@Throws(IllegalStateException::class)
+/**
+ * Creates a value for a given numeric type, excluding generics like List or Array.
+ * @param T the type which is supposed to be created.
+ * @param sign determines if the resulting number is strict positive or negative
+ * @param qualifier a optional qualifier for a special flavour of a type.
+ * @throws IllegalStateException if the no matching Generator was found for the given type.
+ */
+public inline fun <reified T> PublicApi.Fixture.fixture(
+    sign: PublicApi.Sign,
+    qualifier: PublicApi.Qualifier? = null,
+): T where T : Number? {
+    val returnNull = random.returnNull<T>()
+    val id = resolveIdentifier<T>(qualifier)
+    val generator = generators[id]
+
+    @Suppress("UNCHECKED_CAST")
+    return when {
+        generator !is PublicApi.SignedNumberGenerator<*> -> {
+            throw IllegalStateException("Missing Generator for ClassID ($id).")
+        }
+        returnNull -> null as T
+        else -> (generator as PublicApi.SignedNumberGenerator<Comparable<Any>>).generate(sign) as T
+    }
+}

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/primitive/ByteGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/primitive/ByteGenerator.kt
@@ -6,11 +6,37 @@
 
 package tech.antibytes.kfixture.generator.primitive
 
+import kotlin.Byte.Companion.MAX_VALUE
+import kotlin.Byte.Companion.MIN_VALUE
 import kotlin.random.Random
 import tech.antibytes.kfixture.PublicApi
 
 internal class ByteGenerator(
     private val random: Random,
-) : PublicApi.Generator<Byte> {
-    override fun generate(): Byte = random.nextInt().toByte()
+) : PublicApi.SignedNumberGenerator<Byte> {
+    override fun generate(): Byte = generate(MIN_VALUE, MAX_VALUE)
+
+    override fun generate(from: Byte, to: Byte): Byte {
+        return random.nextInt(
+            from = from.toInt(),
+            until = to.toInt() + 1,
+        ).toByte()
+    }
+
+    private fun resolveBoundary(sign: PublicApi.Sign): Pair<Byte, Byte> {
+        return if (sign == PublicApi.Sign.POSITIVE) {
+            ZERO to MAX_VALUE
+        } else {
+            MIN_VALUE to ZERO
+        }
+    }
+
+    override fun generate(sign: PublicApi.Sign): Byte {
+        val (from, to) = resolveBoundary(sign)
+        return generate(from, to)
+    }
+
+    private companion object {
+        const val ZERO = 0.toByte()
+    }
 }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/fixture/RangedFixtureSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/fixture/RangedFixtureSpec.kt
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kfixture.fixture
+
+import kotlin.js.JsName
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.atomicfu.atomic
+import tech.antibytes.kfixture.Fixture
+import tech.antibytes.kfixture.PublicApi
+import tech.antibytes.kfixture.fixture
+import tech.antibytes.kfixture.int
+import tech.antibytes.kfixture.mock.GeneratorStub
+import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.RangedGeneratorStub
+import tech.antibytes.kfixture.qualifier.StringQualifier
+import tech.antibytes.kfixture.resolveClassName
+
+class RangedFixtureSpec {
+    private val random = RandomStub()
+    private val capturedMinimum = atomic(-1)
+    private val capturedMaximum = atomic(-1)
+
+    @AfterTest
+    fun tearDown() {
+        random.clear()
+        capturedMinimum.getAndSet(-1)
+        capturedMaximum.getAndSet(-1)
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn0")
+    fun `It fulfils Fixture`() {
+        val fixture: Any = Fixture(random, emptyMap())
+
+        assertTrue(fixture is PublicApi.Fixture)
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn1")
+    fun `Given fixture is called with a upper and lower bound it fails if the Type has no corresponding Generator`() {
+        // Given
+        val expected = 23
+        val generator = RangedGeneratorStub<Int>()
+        generator.generateWithRange = { _, _ ->
+            expected
+        }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(random, emptyMap())
+
+        // Then
+        val error = assertFailsWith<RuntimeException> {
+            // When
+            fixture.fixture<Int, Int>(
+                from = 0,
+                to = 23,
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Missing Generator for ClassID ($int).",
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given fixture is called with a upper and lower bound it fails the corresponding Generator is not a RangedGenerator`() {
+        // Given
+        val expected = 23
+        val generator = GeneratorStub<Int>()
+        generator.generate = { expected }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(random, mapOf(int to generator))
+
+        // Then
+        val error = assertFailsWith<RuntimeException> {
+            // When
+            fixture.fixture<Int, Int>(
+                from = 0,
+                to = 23,
+            )
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Missing Generator for ClassID ($int).",
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given fixture is called with a upper and lower bound it returns a Fixture for the derived Type`() {
+        // Given
+        val expected = 23
+        val expectedFrom = 12
+        val expectedTo = 42
+        val generator = RangedGeneratorStub<Int>()
+
+        var capturedFrom: Int? = null
+        var capturedTo: Int? = null
+
+        generator.generateWithRange = { givenFrom, givenTo ->
+            capturedFrom = givenFrom
+            capturedTo = givenTo
+
+            expected
+        }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(random, mapOf(int to generator))
+
+        // When
+        val result: Int = fixture.fixture(
+            from = expectedFrom,
+            to = expectedTo,
+        )
+
+        // Then
+        assertEquals(
+            actual = result,
+            expected = expected,
+        )
+        assertEquals(
+            actual = capturedFrom,
+            expected = expectedFrom,
+        )
+        assertEquals(
+            actual = capturedTo,
+            expected = expectedTo,
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given fixture is called with a upper and lower bound it returns a Fixture while respecting nullability`() {
+        // Given
+        val expected = 23
+        val expectedFrom = 12
+        val expectedTo = 42
+        val generator = RangedGeneratorStub<Int>()
+
+        var capturedFrom: Int? = null
+        var capturedTo: Int? = null
+
+        generator.generateWithRange = { givenFrom, givenTo ->
+            capturedFrom = givenFrom
+            capturedTo = givenTo
+
+            expected
+        }
+
+        random.nextBoolean = { true }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(random, mapOf(int to generator))
+
+        // When
+        val result: Int? = fixture.fixture(
+            from = expectedFrom,
+            to = expectedTo,
+        )
+
+        // Then
+        assertNull(result)
+        assertNull(capturedFrom)
+        assertNull(capturedTo)
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given fixture is called  with a upper and lower bound and a qualifier it returns a Fixture for the derived Type`() {
+        // Given
+        val expected = 23
+        val expectedFrom = 12
+        val expectedTo = 42
+        val qualifier = "test"
+        val generator = RangedGeneratorStub<Int>()
+
+        var capturedFrom: Int? = null
+        var capturedTo: Int? = null
+
+        generator.generateWithRange = { givenFrom, givenTo ->
+            capturedFrom = givenFrom
+            capturedTo = givenTo
+
+            expected
+        }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(
+            random,
+            mapOf("q:$qualifier:$int" to generator),
+        )
+
+        // When
+        val result: Int = fixture.fixture(
+            from = expectedFrom,
+            to = expectedTo,
+            qualifier = StringQualifier(qualifier),
+        )
+
+        // Then
+        assertEquals(
+            actual = result,
+            expected = expected,
+        )
+        assertEquals(
+            actual = capturedFrom,
+            expected = expectedFrom,
+        )
+        assertEquals(
+            actual = capturedTo,
+            expected = expectedTo,
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given fixture is called with a range it fails if the Type has no corresponding Generator`() {
+        // Given
+        val expected = 23
+        val generator = RangedGeneratorStub<Int>()
+        generator.generateWithRange = { _, _ ->
+            expected
+        }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(random, emptyMap())
+
+        // Then
+        val error = assertFailsWith<RuntimeException> {
+            // When
+            fixture.fixture<Int, Int>(range = 0..23)
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Missing Generator for ClassID ($int).",
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn7")
+    fun `Given fixture is called with a range it fails the corresponding Generator is not a RangedGenerator`() {
+        // Given
+        val expected = 23
+        val generator = GeneratorStub<Int>()
+        generator.generate = { expected }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(random, mapOf(int to generator))
+
+        // Then
+        val error = assertFailsWith<RuntimeException> {
+            // When
+            fixture.fixture<Int, Int>(range = 0..23)
+        }
+
+        assertEquals(
+            actual = error.message,
+            expected = "Missing Generator for ClassID ($int).",
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn8")
+    fun `Given fixture is called with a range it returns a Fixture for the derived Type`() {
+        // Given
+        val expected = 23
+        val expectedFrom = 12
+        val expectedTo = 42
+        val generator = RangedGeneratorStub<Int>()
+
+        var capturedFrom: Int? = null
+        var capturedTo: Int? = null
+
+        generator.generateWithRange = { givenFrom, givenTo ->
+            capturedFrom = givenFrom
+            capturedTo = givenTo
+
+            expected
+        }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(random, mapOf(int to generator))
+
+        // When
+        val result: Int = fixture.fixture(range = expectedFrom..expectedTo)
+
+        // Then
+        assertEquals(
+            actual = result,
+            expected = expected,
+        )
+        assertEquals(
+            actual = capturedFrom,
+            expected = expectedFrom,
+        )
+        assertEquals(
+            actual = capturedTo,
+            expected = expectedTo,
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn9")
+    fun `Given fixture is called with a range it returns a Fixture while respecting nullability`() {
+        // Given
+        val expected = 23
+        val expectedFrom = 12
+        val expectedTo = 42
+        val generator = RangedGeneratorStub<Int>()
+
+        var capturedFrom: Int? = null
+        var capturedTo: Int? = null
+
+        generator.generateWithRange = { givenFrom, givenTo ->
+            capturedFrom = givenFrom
+            capturedTo = givenTo
+
+            expected
+        }
+
+        random.nextBoolean = { true }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(random, mapOf(int to generator))
+
+        // When
+        val result: Int? = fixture.fixture(range = expectedFrom..expectedTo)
+
+        // Then
+        assertNull(result)
+        assertNull(capturedFrom)
+        assertNull(capturedTo)
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn10")
+    fun `Given fixture is called with a range and a qualifier it returns a Fixture for the derived Type`() {
+        // Given
+        val expected = 23
+        val expectedFrom = 12
+        val expectedTo = 42
+        val qualifier = "test"
+        val generator = RangedGeneratorStub<Int>()
+
+        var capturedFrom: Int? = null
+        var capturedTo: Int? = null
+
+        generator.generateWithRange = { givenFrom, givenTo ->
+            capturedFrom = givenFrom
+            capturedTo = givenTo
+
+            expected
+        }
+
+        // Ensure stable names since reified is in play
+        resolveClassName(Int::class)
+
+        val fixture = Fixture(
+            random,
+            mapOf("q:$qualifier:$int" to generator),
+        )
+
+        // When
+        val result: Int = fixture.fixture(
+            expectedFrom..expectedTo,
+            qualifier = StringQualifier(qualifier),
+        )
+
+        // Then
+        assertEquals(
+            actual = result,
+            expected = expected,
+        )
+        assertEquals(
+            actual = capturedFrom,
+            expected = expectedFrom,
+        )
+        assertEquals(
+            actual = capturedTo,
+            expected = expectedTo,
+        )
+    }
+}

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/primitive/ByteGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/primitive/ByteGeneratorSpec.kt
@@ -10,6 +10,8 @@ import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
@@ -25,10 +27,10 @@ class ByteGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils SignedNumberGenerator`() {
         val generator: Any = ByteGenerator(random)
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.SignedNumberGenerator<*>)
     }
 
     @Test
@@ -37,7 +39,7 @@ class ByteGeneratorSpec {
     fun `Given generate is called it returns a Byte`() {
         // Given
         val expected = 23
-        random.nextInt = { expected }
+        random.nextIntRanged = { _, _ -> expected }
 
         val generator = ByteGenerator(random)
 
@@ -48,6 +50,150 @@ class ByteGeneratorSpec {
         assertEquals(
             actual = result,
             expected = expected.toByte(),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a range it fails since the start is less equal to the end`() {
+        // Given
+        val expected = IllegalArgumentException()
+
+        random.nextIntRanged = { _, _ -> throw expected }
+
+        val generator = ByteGenerator(random)
+
+        // Then
+        val error = assertFailsWith<IllegalArgumentException> {
+            // When
+            generator.generate(-1, 0)
+        }
+
+        // Then
+        assertSame(
+            actual = error,
+            expected = expected,
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a Byte`() {
+        // Given
+        val expected = 107
+        val expectedMin = 0.toByte()
+        val expectedMax = 42.toByte()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        random.nextIntRanged = { givenMin, givenMax ->
+            capturedMin = givenMin
+            capturedMax = givenMax
+
+            expected
+        }
+
+        val generator = ByteGenerator(random)
+
+        // When
+        val result = generator.generate(
+            from = expectedMin,
+            to = expectedMax,
+        )
+
+        // Then
+        assertEquals(
+            actual = result,
+            expected = expected.toByte(),
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt() + 1,
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with POSITIVE it returns a Byte`() {
+        // Given
+        val expected = 107
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        random.nextIntRanged = { givenMin, givenMax ->
+            capturedMin = givenMin
+            capturedMax = givenMax
+
+            expected
+        }
+
+        val generator = ByteGenerator(random)
+
+        // When
+        val result = generator.generate(
+            PublicApi.Sign.POSITIVE,
+        )
+
+        // Then
+        assertEquals(
+            actual = result,
+            expected = expected.toByte(),
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = 0,
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = Byte.MAX_VALUE + 1,
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with NEGATIVE it returns a Byte`() {
+        // Given
+        val expected = 107
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        random.nextIntRanged = { givenMin, givenMax ->
+            capturedMin = givenMin
+            capturedMax = givenMax
+
+            expected
+        }
+
+        val generator = ByteGenerator(random)
+
+        // When
+        val result = generator.generate(
+            PublicApi.Sign.NEGATIVE,
+        )
+
+        // Then
+        assertEquals(
+            actual = result,
+            expected = expected.toByte(),
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = Byte.MIN_VALUE.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = 1,
         )
     }
 }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/mock/RangedGeneratorStub.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/mock/RangedGeneratorStub.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kfixture.mock
+
+import kotlin.js.JsName
+import tech.antibytes.kfixture.PublicApi
+
+class RangedGeneratorStub<T>(
+    @JsName("generateStub")
+    var generate: (() -> T)? = null,
+    @JsName("generateWithRangeStub")
+    var generateWithRange: ((T, T) -> T)? = null,
+) : PublicApi.RangedGenerator<T> where T : Any, T : Comparable<T> {
+    override fun generate(): T {
+        return generate?.invoke() ?: throw RuntimeException("Missing SideEffect for generate.")
+    }
+
+    override fun generate(from: T, to: T): T {
+        return generateWithRange?.invoke(from, to)
+            ?: throw RuntimeException("Missing SideEffect for generateWithRange.")
+    }
+}

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/mock/SignedNumberGeneratorStub.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/mock/SignedNumberGeneratorStub.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kfixture.mock
+
+import kotlin.js.JsName
+import tech.antibytes.kfixture.PublicApi
+
+class SignedNumberGeneratorStub<T>(
+    @JsName("generateStub")
+    var generate: (() -> T)? = null,
+    @JsName("generateWithRangeStub")
+    var generateWithRange: ((T, T) -> T)? = null,
+    @JsName("generateWithSignStub")
+    var generateWithSign: ((PublicApi.Sign) -> T)? = null,
+) : PublicApi.SignedNumberGenerator<T> where T : Number, T : Comparable<T> {
+    override fun generate(): T {
+        return generate?.invoke() ?: throw RuntimeException("Missing SideEffect for generate.")
+    }
+
+    override fun generate(from: T, to: T): T {
+        return generateWithRange?.invoke(from, to)
+            ?: throw RuntimeException("Missing SideEffect for generateWithRange.")
+    }
+
+    override fun generate(sign: PublicApi.Sign): T {
+        return generateWithSign?.invoke(sign)
+            ?: throw RuntimeException("Missing SideEffect for generateWithType.")
+    }
+}


### PR DESCRIPTION
### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This adds Ranged & SignedNumberGenerator for Byte as a first step to make the handling with numeric based values easier and to get an easy to use handle on for example positive Integers. Both new generator are introducing boundaries which can be used to delegate it to the relating Generators.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [x] My changes update the documentation.
- [x] My changes are reflected in the changelog.
