### PR TITLE
Add generator with dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Long
     - Float
     - Double
+* DependentGeneratorFactory in order to build Generators on top of other Generators
 
 ### Changed
 

--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -43,13 +43,19 @@ public abstract interface class tech/antibytes/kfixture/PublicApi {
 }
 
 public abstract interface class tech/antibytes/kfixture/PublicApi$Configuration {
+	public abstract fun addGenerator (Lkotlin/reflect/KClass;Ltech/antibytes/kfixture/PublicApi$DependentGeneratorFactory;Ltech/antibytes/kfixture/PublicApi$Qualifier;)Ltech/antibytes/kfixture/PublicApi$Configuration;
 	public abstract fun addGenerator (Lkotlin/reflect/KClass;Ltech/antibytes/kfixture/PublicApi$GeneratorFactory;Ltech/antibytes/kfixture/PublicApi$Qualifier;)Ltech/antibytes/kfixture/PublicApi$Configuration;
 	public abstract fun getSeed ()I
 	public abstract fun setSeed (I)V
 }
 
 public final class tech/antibytes/kfixture/PublicApi$Configuration$DefaultImpls {
+	public static synthetic fun addGenerator$default (Ltech/antibytes/kfixture/PublicApi$Configuration;Lkotlin/reflect/KClass;Ltech/antibytes/kfixture/PublicApi$DependentGeneratorFactory;Ltech/antibytes/kfixture/PublicApi$Qualifier;ILjava/lang/Object;)Ltech/antibytes/kfixture/PublicApi$Configuration;
 	public static synthetic fun addGenerator$default (Ltech/antibytes/kfixture/PublicApi$Configuration;Lkotlin/reflect/KClass;Ltech/antibytes/kfixture/PublicApi$GeneratorFactory;Ltech/antibytes/kfixture/PublicApi$Qualifier;ILjava/lang/Object;)Ltech/antibytes/kfixture/PublicApi$Configuration;
+}
+
+public abstract interface class tech/antibytes/kfixture/PublicApi$DependentGeneratorFactory {
+	public abstract fun getInstance (Lkotlin/random/Random;Ljava/util/Map;)Ltech/antibytes/kfixture/PublicApi$Generator;
 }
 
 public abstract interface class tech/antibytes/kfixture/PublicApi$Fixture {

--- a/core/api/jvm/core.api
+++ b/core/api/jvm/core.api
@@ -36,13 +36,19 @@ public abstract interface class tech/antibytes/kfixture/PublicApi {
 }
 
 public abstract interface class tech/antibytes/kfixture/PublicApi$Configuration {
+	public abstract fun addGenerator (Lkotlin/reflect/KClass;Ltech/antibytes/kfixture/PublicApi$DependentGeneratorFactory;Ltech/antibytes/kfixture/PublicApi$Qualifier;)Ltech/antibytes/kfixture/PublicApi$Configuration;
 	public abstract fun addGenerator (Lkotlin/reflect/KClass;Ltech/antibytes/kfixture/PublicApi$GeneratorFactory;Ltech/antibytes/kfixture/PublicApi$Qualifier;)Ltech/antibytes/kfixture/PublicApi$Configuration;
 	public abstract fun getSeed ()I
 	public abstract fun setSeed (I)V
 }
 
 public final class tech/antibytes/kfixture/PublicApi$Configuration$DefaultImpls {
+	public static synthetic fun addGenerator$default (Ltech/antibytes/kfixture/PublicApi$Configuration;Lkotlin/reflect/KClass;Ltech/antibytes/kfixture/PublicApi$DependentGeneratorFactory;Ltech/antibytes/kfixture/PublicApi$Qualifier;ILjava/lang/Object;)Ltech/antibytes/kfixture/PublicApi$Configuration;
 	public static synthetic fun addGenerator$default (Ltech/antibytes/kfixture/PublicApi$Configuration;Lkotlin/reflect/KClass;Ltech/antibytes/kfixture/PublicApi$GeneratorFactory;Ltech/antibytes/kfixture/PublicApi$Qualifier;ILjava/lang/Object;)Ltech/antibytes/kfixture/PublicApi$Configuration;
+}
+
+public abstract interface class tech/antibytes/kfixture/PublicApi$DependentGeneratorFactory {
+	public abstract fun getInstance (Lkotlin/random/Random;Ljava/util/Map;)Ltech/antibytes/kfixture/PublicApi$Generator;
 }
 
 public abstract interface class tech/antibytes/kfixture/PublicApi$Fixture {

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/PublicApi.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/PublicApi.kt
@@ -86,6 +86,26 @@ public interface PublicApi {
     }
 
     /**
+     * Factory of a Generator which has dependencies on other Generators
+     * @param T the type which the Generator is referring to.
+     * @see Generator
+     * @author Matthias Geisler
+     */
+    public interface DependentGeneratorFactory<T : Any> {
+        /**
+         * Instantiates a Generator
+         * @param random a shared instance of Random.
+         * @param generators a Map which holds already registered Generators.
+         * @see Random
+         * @return a instance of a Generator
+         */
+        public fun getInstance(
+            random: Random,
+            generators: Map<String, Generator<out Any>>,
+        ): Generator<T>
+    }
+
+    /**
      * Indicator to identify a special flavour of a Generator
      * @see Generator
      * @author Matthias Geisler
@@ -124,21 +144,39 @@ public interface PublicApi {
             factory: GeneratorFactory<T>,
             qualifier: Qualifier? = null,
         ): Configuration
+
+        /**
+         * Adds a custom Generator to Fixture Generator.
+         * However build in types cannot be overridden.
+         * @param T the type which the Generator is referring to.
+         * @param clazz a KClass the generator is referring to.
+         * @param factory the Factory which has dependencies for the Generator.
+         * @param qualifier optional Qualifier which can be to differ between flavours of the same type.
+         * @return Configuration the current instance of the Configuration.
+         * @see Generator
+         * @see GeneratorFactory
+         * @see Qualifier
+         */
+        public fun <T : Any> addGenerator(
+            clazz: KClass<T>,
+            factory: DependentGeneratorFactory<T>,
+            qualifier: Qualifier? = null,
+        ): Configuration
     }
 
     /**
-     * Fixture Generator
+     * Fixture Generator.
      *
      * @author Matthias Geisler
      */
     public interface Fixture {
         /**
-         * Random Generator which is used to generate atomic types
+         * Random Generator which is used to generate atomic types.
          */
         public val random: Random
 
         /**
-         * Map which holds all registers Generators
+         * Map which holds all registers Generators.
          */
         public val generators: Map<String, Generator<out Any>>
     }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/mock/ConfigurationStub.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/mock/ConfigurationStub.kt
@@ -24,4 +24,12 @@ class ConfigurationStub(
 
         return this
     }
+
+    override fun <T : Any> addGenerator(
+        clazz: KClass<T>,
+        factory: PublicApi.DependentGeneratorFactory<T>,
+        qualifier: PublicApi.Qualifier?,
+    ): PublicApi.Configuration {
+        TODO("Not yet implemented")
+    }
 }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/mock/DependentGeneratorStub.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/mock/DependentGeneratorStub.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kfixture.mock
+
+import kotlin.js.JsName
+import kotlin.random.Random
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import tech.antibytes.kfixture.PublicApi
+
+class DependentGeneratorStub<T : Any>(
+    @JsName("dependentGenerateStub")
+    var generate: (() -> T)? = null,
+) : PublicApi.Generator<T> {
+    override fun generate(): T {
+        return generate?.invoke() ?: throw RuntimeException("Missing sideeffect for generate.")
+    }
+}
+
+class DependentGeneratorFactoryStub<T : Any>(
+    @JsName("dependentGenerateStub")
+    var generate: (() -> T)? = null,
+) : PublicApi.DependentGeneratorFactory<T> {
+    private val _lastRandom: AtomicRef<Random> = atomic(Random(49))
+    private val _lastInstance: AtomicRef<DependentGeneratorStub<T>?> = atomic(null)
+    private val _lastGenerators: AtomicRef<Map<String, PublicApi.Generator<out Any>>?> = atomic(null)
+
+    var lastRandom by _lastRandom
+    var lastInstance by _lastInstance
+    var lastGenerators by _lastGenerators
+
+    override fun getInstance(
+        random: Random,
+        generators: Map<String, PublicApi.Generator<out Any>>,
+    ): PublicApi.Generator<T> {
+        return DependentGeneratorStub(generate).also {
+            lastRandom = random
+            lastInstance = it
+            lastGenerators = generators
+        }
+    }
+}


### PR DESCRIPTION
### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This simply enables Generator to have dependencies on other generators by delegating the accumulated Generators to the Factories.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
