### PR TITLE
Change IntArray and UIntArray generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Double
 * RangedArrayGenerator for:
     - UByteArray
+    - UShortArray
 * SignedArrayNumberGenerator for:
     - ByteArray
+    - ShortArray
 * DependentGeneratorFactory in order to build Generators on top of other Generators
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * RangedArrayGenerator for:
     - UByteArray
     - UShortArray
+    - UIntArray
 * SignedArrayNumberGenerator for:
     - ByteArray
     - ShortArray
+    - IntArray
 * DependentGeneratorFactory in order to build Generators on top of other Generators
 
 ### Changed

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
@@ -55,7 +55,6 @@ internal class Configuration(
             resolveClassName(BooleanArray::class) to BooleanArrayGenerator(random),
             resolveClassName(Short::class) to ShortGenerator(random),
             resolveClassName(Int::class) to IntegerGenerator(random),
-            resolveClassName(IntArray::class) to IntArrayGenerator(random),
             resolveClassName(Float::class) to FloatGenerator(random),
             resolveClassName(FloatArray::class) to FloatArrayGenerator(random),
             resolveClassName(Char::class) to CharGenerator(random),
@@ -67,7 +66,6 @@ internal class Configuration(
             resolveClassName(String::class) to StringGenerator(random),
             resolveClassName(UShort::class) to UShortGenerator(random),
             resolveClassName(UInt::class) to UIntegerGenerator(random),
-            resolveClassName(UIntArray::class) to UIntArrayGenerator(random),
             resolveClassName(ULong::class) to ULongGenerator(random),
             resolveClassName(ULongArray::class) to ULongArrayGenerator(random),
             resolveClassName(UByte::class) to UByteGenerator(random),
@@ -106,6 +104,14 @@ internal class Configuration(
             this[resolveClassName(UShortArray::class)] = UShortArrayGenerator(
                 random,
                 this.resolveRangedGenerator(resolveClassName(UShort::class)),
+            )
+            this[resolveClassName(IntArray::class)] = IntArrayGenerator(
+                random,
+                this.resolveSignedGenerator(resolveClassName(Int::class)),
+            )
+            this[resolveClassName(UIntArray::class)] = UIntArrayGenerator(
+                random,
+                this.resolveRangedGenerator(resolveClassName(UInt::class)),
             )
         }
     }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
@@ -54,7 +54,6 @@ internal class Configuration(
             resolveClassName(Byte::class) to ByteGenerator(random),
             resolveClassName(BooleanArray::class) to BooleanArrayGenerator(random),
             resolveClassName(Short::class) to ShortGenerator(random),
-            resolveClassName(ShortArray::class) to ShortArrayGenerator(random),
             resolveClassName(Int::class) to IntegerGenerator(random),
             resolveClassName(IntArray::class) to IntArrayGenerator(random),
             resolveClassName(Float::class) to FloatGenerator(random),
@@ -67,7 +66,6 @@ internal class Configuration(
             resolveClassName(DoubleArray::class) to DoubleArrayGenerator(random),
             resolveClassName(String::class) to StringGenerator(random),
             resolveClassName(UShort::class) to UShortGenerator(random),
-            resolveClassName(UShortArray::class) to UShortArrayGenerator(random),
             resolveClassName(UInt::class) to UIntegerGenerator(random),
             resolveClassName(UIntArray::class) to UIntArrayGenerator(random),
             resolveClassName(ULong::class) to ULongGenerator(random),
@@ -100,6 +98,14 @@ internal class Configuration(
             this[resolveClassName(UByteArray::class)] = UByteArrayGenerator(
                 random,
                 this.resolveRangedGenerator(resolveClassName(UByte::class)),
+            )
+            this[resolveClassName(ShortArray::class)] = ShortArrayGenerator(
+                random,
+                this.resolveSignedGenerator(resolveClassName(Short::class)),
+            )
+            this[resolveClassName(UShortArray::class)] = UShortArrayGenerator(
+                random,
+                this.resolveRangedGenerator(resolveClassName(UShort::class)),
             )
         }
     }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGenerator.kt
@@ -7,27 +7,15 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class IntArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<IntArray> {
-    private fun generateIntArray(size: Int): IntArray {
-        val raw = random.nextBytes(size)
-        val fixture = IntArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toInt()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): IntArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateIntArray(size)
-    }
+    random: Random,
+    intGenerator: PublicApi.SignedNumberGenerator<Int, Int>,
+) : PublicApi.SignedNumericArrayGenerator<Int, IntArray>,
+    SignedArrayNumberGenerator<Int, IntArray>(random, intGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> Int,
+    ): IntArray = IntArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/ShortArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/ShortArrayGenerator.kt
@@ -7,27 +7,15 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class ShortArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<ShortArray> {
-    private fun generateShortArray(size: Int): ShortArray {
-        val raw = random.nextBytes(size)
-        val fixture = ShortArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toShort()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): ShortArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateShortArray(size)
-    }
+    random: Random,
+    shortGenerator: PublicApi.SignedNumberGenerator<Short, Short>,
+) : PublicApi.SignedNumericArrayGenerator<Short, ShortArray>,
+    SignedArrayNumberGenerator<Short, ShortArray>(random, shortGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> Short,
+    ): ShortArray = ShortArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGenerator.kt
@@ -7,28 +7,14 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import kotlin.random.nextUBytes
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class UIntArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<UIntArray> {
-    private fun generateUIntArray(size: Int): UIntArray {
-        val raw = random.nextUBytes(size)
-        val fixture = UIntArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toUInt()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): UIntArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateUIntArray(size)
-    }
+    random: Random,
+    uShortGenerator: PublicApi.RangedGenerator<UInt, UInt>,
+) : RangedArrayNumberGenerator<UInt, UIntArray>(random, uShortGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> UInt,
+    ): UIntArray = UIntArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/UShortArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/UShortArrayGenerator.kt
@@ -7,28 +7,14 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import kotlin.random.nextUBytes
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class UShortArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<UShortArray> {
-    private fun generateUShortArray(size: Int): UShortArray {
-        val raw = random.nextUBytes(size)
-        val fixture = UShortArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toUShort()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): UShortArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateUShortArray(size)
-    }
+    random: Random,
+    uShortGenerator: PublicApi.RangedGenerator<UShort, UShort>,
+) : RangedArrayNumberGenerator<UShort, UShortArray>(random, uShortGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> UShort,
+    ): UShortArray = UShortArray(size, onEach)
 }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.SignedNumberGeneratorStub
 
 class IntArrayGeneratorSpec {
     private val random = RandomStub()
@@ -31,7 +33,7 @@ class IntArrayGeneratorSpec {
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = IntArrayGenerator(random)
+        val generator: Any = IntArrayGenerator(random, SignedNumberGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
@@ -42,18 +44,19 @@ class IntArrayGeneratorSpec {
     fun `Given generate is called it returns a IntArray`() {
         // Given
         val size = 23
-        val expected = IntArray(size)
-        val generator = IntArrayGenerator(random)
+        val expectedValue = 23
+        val expected = IntArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
-        val result: IntArray = generator.generate()
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate()
 
         // Then
         assertEquals(
@@ -61,7 +64,346 @@ class IntArrayGeneratorSpec {
             expected = range.value,
         )
         assertTrue(
-            expected.map { byte -> byte }.toIntArray().contentEquals(result),
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a IntArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23
+        val expected = IntArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a IntArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0
+        val expectedMax = 42
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expected = listOf(
+            23,
+            7,
+            39,
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin
+            capturedMax = givenMax
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin,
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax,
+        )
+        assertTrue(
+            expected.toIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a IntArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0
+        val expectedMax = 42
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expected = listOf(
+            23,
+            7,
+            39,
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin
+            capturedMax = givenMax
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin,
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax,
+        )
+        assertTrue(
+            expected.toIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a IntArray`() {
+        // Given
+        val expectedMin1 = 0
+        val expectedMax1 = 42
+        val expectedMin2 = 3
+        val expectedMax2 = 41
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expected = listOf(
+            23,
+            7,
+            39,
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin)
+            capturedMax.add(givenMax)
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            IntRange(expectedMin1, expectedMax1),
+            IntRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1 in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2 in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1 in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2 in capturedMax,
+        )
+
+        assertTrue(
+            expected.toIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a IntArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0
+        val expectedMax1 = 42
+        val expectedMin2 = 3
+        val expectedMax2 = 41
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expected = listOf(
+            23,
+            7,
+            39,
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin)
+            capturedMax.add(givenMax)
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            IntRange(expectedMin1, expectedMax1),
+            IntRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1 in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2 in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1 in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2 in capturedMax,
+        )
+
+        assertTrue(
+            expected.toIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn7")
+    fun `Given generate is called with a Sign it returns a IntArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expectedValue = 42
+        val expected = IntArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn8")
+    fun `Given generate is called with a Sign and Size it returns a IntArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expectedValue = 42
+        val expected = IntArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign, size)
+
+        // Then
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
         )
     }
 }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ShortArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ShortArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.SignedNumberGeneratorStub
 
 class ShortArrayGeneratorSpec {
     private val random = RandomStub()
@@ -31,7 +33,7 @@ class ShortArrayGeneratorSpec {
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = ShortArrayGenerator(random)
+        val generator: Any = ShortArrayGenerator(random, SignedNumberGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
@@ -42,18 +44,19 @@ class ShortArrayGeneratorSpec {
     fun `Given generate is called it returns a ShortArray`() {
         // Given
         val size = 23
-        val expected = ShortArray(size)
-        val generator = ShortArrayGenerator(random)
+        val expectedValue = 23.toShort()
+        val expected = ShortArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Short, Short>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
-        val result: ShortArray = generator.generate()
+        val generator = ShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate()
 
         // Then
         assertEquals(
@@ -61,7 +64,351 @@ class ShortArrayGeneratorSpec {
             expected = range.value,
         )
         assertTrue(
-            expected.map { byte -> byte }.toShortArray().contentEquals(result),
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a ShortArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23.toShort()
+        val expected = ShortArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Short, Short>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = ShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a ShortArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toShort()
+        val expectedMax = 42.toShort()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Short, Short>()
+
+        val expected = listOf(
+            23.toShort(),
+            7.toShort(),
+            39.toShort(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toShortArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a ShortArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toShort()
+        val expectedMax = 42.toShort()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Short, Short>()
+
+        val expected = listOf(
+            23.toShort(),
+            7.toShort(),
+            39.toShort(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toShortArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a ShortArray`() {
+        // Given
+        val expectedMin1 = 0.toShort()
+        val expectedMax1 = 42.toShort()
+        val expectedMin2 = 3.toShort()
+        val expectedMax2 = 41.toShort()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Short, Short>()
+
+        val expected = listOf(
+            23.toShort(),
+            7.toShort(),
+            39.toShort(),
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            ShortRange(expectedMin1, expectedMax1),
+            ShortRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toShortArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a ShortArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0.toShort()
+        val expectedMax1 = 42.toShort()
+        val expectedMin2 = 3.toShort()
+        val expectedMax2 = 41.toShort()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Short, Short>()
+
+        val expected = listOf(
+            23.toShort(),
+            7.toShort(),
+            39.toShort(),
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            ShortRange(expectedMin1, expectedMax1),
+            ShortRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toShortArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn7")
+    fun `Given generate is called with a Sign it returns a ShortArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Short, Short>()
+
+        val expectedValue = 42.toShort()
+        val expected = ShortArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        // When
+        val generator = ShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn8")
+    fun `Given generate is called with a Sign and Size it returns a ShortArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Short, Short>()
+
+        val expectedValue = 42.toShort()
+        val expected = ShortArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+
+        // When
+        val generator = ShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign, size)
+
+        // Then
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
         )
     }
 }
+
+private data class ShortRange(
+    override val start: Short,
+    override val endInclusive: Short,
+) : ClosedRange<Short>

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.RangedGeneratorStub
 
 class UIntArrayGeneratorSpec {
     private val random = RandomStub()
@@ -24,36 +26,36 @@ class UIntArrayGeneratorSpec {
     @AfterTest
     fun tearDown() {
         random.clear()
-        range.update { null }
+        range.getAndSet(null)
     }
 
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = UIntArrayGenerator(random)
+        val generator: Any = UIntArrayGenerator(random, RangedGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn1")
     fun `Given generate is called it returns a UIntArray`() {
         // Given
         val size = 23
-        val expected = UIntArray(size)
-        val generator = UIntArrayGenerator(random)
+        val expectedValue = 23.toUInt()
+        val expected = UIntArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
         val result = generator.generate()
 
         // Then
@@ -65,4 +67,270 @@ class UIntArrayGeneratorSpec {
             expected.contentEquals(result),
         )
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a UIntArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23.toUInt()
+        val expected = UIntArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a UIntArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toUInt()
+        val expectedMax = 42.toUInt()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        val expected = listOf(
+            23.toUInt(),
+            7.toUInt(),
+            39.toUInt(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toUIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a UIntArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toUInt()
+        val expectedMax = 42.toUInt()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        val expected = listOf(
+            23.toUInt(),
+            7.toUInt(),
+            39.toUInt(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toUIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a UIntArray`() {
+        // Given
+        val expectedMin1 = 0.toUInt()
+        val expectedMax1 = 42.toUInt()
+        val expectedMin2 = 3.toUInt()
+        val expectedMax2 = 41.toUInt()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        val expected = listOf(
+            23.toUInt(),
+            7.toUInt(),
+            39.toUInt(),
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            UIntRange(expectedMin1, expectedMax1),
+            UIntRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toUIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a UIntArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0.toUInt()
+        val expectedMax1 = 42.toUInt()
+        val expectedMin2 = 3.toUInt()
+        val expectedMax2 = 41.toUInt()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        val expected = listOf(
+            23.toUInt(),
+            7.toUInt(),
+            39.toUInt(),
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            UIntRange(expectedMin1, expectedMax1),
+            UIntRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toUIntArray().contentEquals(result),
+        )
+    }
 }
+
+private data class UIntRange(
+    override val start: UInt,
+    override val endInclusive: UInt,
+) : ClosedRange<UInt>

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UShortArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UShortArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.RangedGeneratorStub
 
 class UShortArrayGeneratorSpec {
     private val random = RandomStub()
@@ -24,36 +26,36 @@ class UShortArrayGeneratorSpec {
     @AfterTest
     fun tearDown() {
         random.clear()
-        range.update { null }
+        range.getAndSet(null)
     }
 
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = UShortArrayGenerator(random)
+        val generator: Any = UShortArrayGenerator(random, RangedGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn1")
     fun `Given generate is called it returns a UShortArray`() {
         // Given
         val size = 23
-        val expected = UShortArray(size)
-        val generator = UShortArrayGenerator(random)
+        val expectedValue = 23.toUShort()
+        val expected = UShortArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<UShort, UShort>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
+        val generator = UShortArrayGenerator(random, auxiliaryGenerator)
         val result = generator.generate()
 
         // Then
@@ -65,4 +67,270 @@ class UShortArrayGeneratorSpec {
             expected.contentEquals(result),
         )
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a UShortArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23.toUShort()
+        val expected = UShortArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<UShort, UShort>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = UShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a UShortArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toUShort()
+        val expectedMax = 42.toUShort()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<UShort, UShort>()
+
+        val expected = listOf(
+            23.toUShort(),
+            7.toUShort(),
+            39.toUShort(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toUShortArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a UShortArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toUShort()
+        val expectedMax = 42.toUShort()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<UShort, UShort>()
+
+        val expected = listOf(
+            23.toUShort(),
+            7.toUShort(),
+            39.toUShort(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toUShortArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a UShortArray`() {
+        // Given
+        val expectedMin1 = 0.toUShort()
+        val expectedMax1 = 42.toUShort()
+        val expectedMin2 = 3.toUShort()
+        val expectedMax2 = 41.toUShort()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<UShort, UShort>()
+
+        val expected = listOf(
+            23.toUShort(),
+            7.toUShort(),
+            39.toUShort(),
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            UShortRange(expectedMin1, expectedMax1),
+            UShortRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toUShortArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a UShortArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0.toUShort()
+        val expectedMax1 = 42.toUShort()
+        val expectedMin2 = 3.toUShort()
+        val expectedMax2 = 41.toUShort()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<UShort, UShort>()
+
+        val expected = listOf(
+            23.toUShort(),
+            7.toUShort(),
+            39.toUShort(),
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UShortArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            UShortRange(expectedMin1, expectedMax1),
+            UShortRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toUShortArray().contentEquals(result),
+        )
+    }
 }
+
+private data class UShortRange(
+    override val start: UShort,
+    override val endInclusive: UShort,
+) : ClosedRange<UShort>


### PR DESCRIPTION
### :pushpin: References
* **Related PRs:** #36

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This migrates the IntArrayGenertator to SignedNumericArrayGenerator and the UIntArrayGenertator to RangedArrayGenerator.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
