### PR TITLE
Change LongArrayGenerator and ULongArrayGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * RangedArrayGenerator for:
     - UByteArray
     - UShortArray
+    - UIntArray
 * SignedArrayNumberGenerator for:
     - ByteArray
     - ShortArray
+    - IntArray
 * DependentGeneratorFactory in order to build Generators on top of other Generators
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - UByteArray
     - UShortArray
     - UIntArray
+    - ULongArray
 * SignedArrayNumberGenerator for:
     - ByteArray
     - ShortArray
     - IntArray
+    - LongArray
 * DependentGeneratorFactory in order to build Generators on top of other Generators
 
 ### Changed

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
@@ -60,14 +60,12 @@ internal class Configuration(
             resolveClassName(Char::class) to CharGenerator(random),
             resolveClassName(CharArray::class) to CharArrayGenerator(random),
             resolveClassName(Long::class) to LongGenerator(random),
-            resolveClassName(LongArray::class) to LongArrayGenerator(random),
             resolveClassName(Double::class) to DoubleGenerator(random),
             resolveClassName(DoubleArray::class) to DoubleArrayGenerator(random),
             resolveClassName(String::class) to StringGenerator(random),
             resolveClassName(UShort::class) to UShortGenerator(random),
             resolveClassName(UInt::class) to UIntegerGenerator(random),
             resolveClassName(ULong::class) to ULongGenerator(random),
-            resolveClassName(ULongArray::class) to ULongArrayGenerator(random),
             resolveClassName(UByte::class) to UByteGenerator(random),
             resolveClassName(Any::class) to AnyGenerator,
             resolveClassName(Unit::class) to UnitGenerator,
@@ -112,6 +110,14 @@ internal class Configuration(
             this[resolveClassName(UIntArray::class)] = UIntArrayGenerator(
                 random,
                 this.resolveRangedGenerator(resolveClassName(UInt::class)),
+            )
+            this[resolveClassName(LongArray::class)] = LongArrayGenerator(
+                random,
+                this.resolveSignedGenerator(resolveClassName(Long::class)),
+            )
+            this[resolveClassName(ULongArray::class)] = ULongArrayGenerator(
+                random,
+                this.resolveRangedGenerator(resolveClassName(ULong::class)),
             )
         }
     }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
@@ -55,7 +55,6 @@ internal class Configuration(
             resolveClassName(BooleanArray::class) to BooleanArrayGenerator(random),
             resolveClassName(Short::class) to ShortGenerator(random),
             resolveClassName(Int::class) to IntegerGenerator(random),
-            resolveClassName(IntArray::class) to IntArrayGenerator(random),
             resolveClassName(Float::class) to FloatGenerator(random),
             resolveClassName(FloatArray::class) to FloatArrayGenerator(random),
             resolveClassName(Char::class) to CharGenerator(random),
@@ -67,7 +66,6 @@ internal class Configuration(
             resolveClassName(String::class) to StringGenerator(random),
             resolveClassName(UShort::class) to UShortGenerator(random),
             resolveClassName(UInt::class) to UIntegerGenerator(random),
-            resolveClassName(UIntArray::class) to UIntArrayGenerator(random),
             resolveClassName(ULong::class) to ULongGenerator(random),
             resolveClassName(ULongArray::class) to ULongArrayGenerator(random),
             resolveClassName(UByte::class) to UByteGenerator(random),
@@ -106,6 +104,14 @@ internal class Configuration(
             this[resolveClassName(UShortArray::class)] = UShortArrayGenerator(
                 random,
                 this.resolveRangedGenerator(resolveClassName(UShort::class)),
+            )
+            this[resolveClassName(IntArray::class)] = IntArrayGenerator(
+                random,
+                this.resolveSignedGenerator(resolveClassName(Int::class)),
+            )
+            this[resolveClassName(UIntArray::class)] = UIntArrayGenerator(
+                random,
+                this.resolveRangedGenerator(resolveClassName(UInt::class)),
             )
         }
     }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGenerator.kt
@@ -7,27 +7,15 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class IntArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<IntArray> {
-    private fun generateIntArray(size: Int): IntArray {
-        val raw = random.nextBytes(size)
-        val fixture = IntArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toInt()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): IntArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateIntArray(size)
-    }
+    random: Random,
+    intGenerator: PublicApi.SignedNumberGenerator<Int, Int>,
+) : PublicApi.SignedNumericArrayGenerator<Int, IntArray>,
+    SignedArrayNumberGenerator<Int, IntArray>(random, intGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> Int,
+    ): IntArray = IntArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGenerator.kt
@@ -7,27 +7,15 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class LongArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<LongArray> {
-    private fun generateLongArray(size: Int): LongArray {
-        val raw = random.nextBytes(size)
-        val fixture = LongArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toLong()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): LongArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateLongArray(size)
-    }
+    random: Random,
+    shortGenerator: PublicApi.SignedNumberGenerator<Long, Long>,
+) : PublicApi.SignedNumericArrayGenerator<Long, LongArray>,
+    SignedArrayNumberGenerator<Long, LongArray>(random, shortGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> Long,
+    ): LongArray = LongArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGenerator.kt
@@ -7,28 +7,14 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import kotlin.random.nextUBytes
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class UIntArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<UIntArray> {
-    private fun generateUIntArray(size: Int): UIntArray {
-        val raw = random.nextUBytes(size)
-        val fixture = UIntArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toUInt()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): UIntArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateUIntArray(size)
-    }
+    random: Random,
+    uShortGenerator: PublicApi.RangedGenerator<UInt, UInt>,
+) : RangedArrayNumberGenerator<UInt, UIntArray>(random, uShortGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> UInt,
+    ): UIntArray = UIntArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGenerator.kt
@@ -7,28 +7,14 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import kotlin.random.nextUBytes
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class ULongArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<ULongArray> {
-    private fun generateULongArray(size: Int): ULongArray {
-        val raw = random.nextUBytes(size)
-        val fixture = ULongArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toULong()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): ULongArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateULongArray(size)
-    }
+    random: Random,
+    uLongGenerator: PublicApi.RangedGenerator<ULong, ULong>,
+) : RangedArrayNumberGenerator<ULong, ULongArray>(random, uLongGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> ULong,
+    ): ULongArray = ULongArray(size, onEach)
 }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.SignedNumberGeneratorStub
 
 class IntArrayGeneratorSpec {
     private val random = RandomStub()
@@ -31,7 +33,7 @@ class IntArrayGeneratorSpec {
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = IntArrayGenerator(random)
+        val generator: Any = IntArrayGenerator(random, SignedNumberGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
@@ -42,18 +44,19 @@ class IntArrayGeneratorSpec {
     fun `Given generate is called it returns a IntArray`() {
         // Given
         val size = 23
-        val expected = IntArray(size)
-        val generator = IntArrayGenerator(random)
+        val expectedValue = 23
+        val expected = IntArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
-        val result: IntArray = generator.generate()
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate()
 
         // Then
         assertEquals(
@@ -61,7 +64,346 @@ class IntArrayGeneratorSpec {
             expected = range.value,
         )
         assertTrue(
-            expected.map { byte -> byte }.toIntArray().contentEquals(result),
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a IntArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23
+        val expected = IntArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a IntArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0
+        val expectedMax = 42
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expected = listOf(
+            23,
+            7,
+            39,
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin
+            capturedMax = givenMax
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin,
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax,
+        )
+        assertTrue(
+            expected.toIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a IntArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0
+        val expectedMax = 42
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expected = listOf(
+            23,
+            7,
+            39,
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin
+            capturedMax = givenMax
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin,
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax,
+        )
+        assertTrue(
+            expected.toIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a IntArray`() {
+        // Given
+        val expectedMin1 = 0
+        val expectedMax1 = 42
+        val expectedMin2 = 3
+        val expectedMax2 = 41
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expected = listOf(
+            23,
+            7,
+            39,
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin)
+            capturedMax.add(givenMax)
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            IntRange(expectedMin1, expectedMax1),
+            IntRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1 in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2 in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1 in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2 in capturedMax,
+        )
+
+        assertTrue(
+            expected.toIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a IntArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0
+        val expectedMax1 = 42
+        val expectedMin2 = 3
+        val expectedMax2 = 41
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expected = listOf(
+            23,
+            7,
+            39,
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin)
+            capturedMax.add(givenMax)
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            IntRange(expectedMin1, expectedMax1),
+            IntRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1 in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2 in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1 in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2 in capturedMax,
+        )
+
+        assertTrue(
+            expected.toIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn7")
+    fun `Given generate is called with a Sign it returns a IntArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expectedValue = 42
+        val expected = IntArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn8")
+    fun `Given generate is called with a Sign and Size it returns a IntArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Int, Int>()
+
+        val expectedValue = 42
+        val expected = IntArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+
+        // When
+        val generator = IntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign, size)
+
+        // Then
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
         )
     }
 }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.SignedNumberGeneratorStub
 
 class LongArrayGeneratorSpec {
     private val random = RandomStub()
@@ -31,7 +33,7 @@ class LongArrayGeneratorSpec {
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = LongArrayGenerator(random)
+        val generator: Any = LongArrayGenerator(random, SignedNumberGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
@@ -42,18 +44,19 @@ class LongArrayGeneratorSpec {
     fun `Given generate is called it returns a LongArray`() {
         // Given
         val size = 23
-        val expected = LongArray(size)
-        val generator = LongArrayGenerator(random)
+        val expectedValue = 23.toLong()
+        val expected = LongArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
-        val result: LongArray = generator.generate()
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate()
 
         // Then
         assertEquals(
@@ -64,4 +67,348 @@ class LongArrayGeneratorSpec {
             expected.contentEquals(result),
         )
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a LongArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23.toLong()
+        val expected = LongArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a LongArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toLong()
+        val expectedMax = 42.toLong()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expected = listOf(
+            23.toLong(),
+            7.toLong(),
+            39.toLong(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toLongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a LongArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toLong()
+        val expectedMax = 42.toLong()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expected = listOf(
+            23.toLong(),
+            7.toLong(),
+            39.toLong(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toLongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a LongArray`() {
+        // Given
+        val expectedMin1 = 0.toLong()
+        val expectedMax1 = 42.toLong()
+        val expectedMin2 = 3.toLong()
+        val expectedMax2 = 41.toLong()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expected = listOf(
+            23.toLong(),
+            7.toLong(),
+            39.toLong(),
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            LongRange(expectedMin1, expectedMax1),
+            LongRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toLongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a LongArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0.toLong()
+        val expectedMax1 = 42.toLong()
+        val expectedMin2 = 3.toLong()
+        val expectedMax2 = 41.toLong()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expected = listOf(
+            23.toLong(),
+            7.toLong(),
+            39.toLong(),
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            LongRange(expectedMin1, expectedMax1),
+            LongRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toLongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn7")
+    fun `Given generate is called with a Sign it returns a LongArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expectedValue = 42.toLong()
+        val expected = LongArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn8")
+    fun `Given generate is called with a Sign and Size it returns a LongArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expectedValue = 42.toLong()
+        val expected = LongArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign, size)
+
+        // Then
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
 }
+
+private data class LongRange(
+    override val start: Long,
+    override val endInclusive: Long,
+) : ClosedRange<Long>

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.RangedGeneratorStub
 
 class UIntArrayGeneratorSpec {
     private val random = RandomStub()
@@ -24,36 +26,36 @@ class UIntArrayGeneratorSpec {
     @AfterTest
     fun tearDown() {
         random.clear()
-        range.update { null }
+        range.getAndSet(null)
     }
 
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = UIntArrayGenerator(random)
+        val generator: Any = UIntArrayGenerator(random, RangedGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn1")
     fun `Given generate is called it returns a UIntArray`() {
         // Given
         val size = 23
-        val expected = UIntArray(size)
-        val generator = UIntArrayGenerator(random)
+        val expectedValue = 23.toUInt()
+        val expected = UIntArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
         val result = generator.generate()
 
         // Then
@@ -65,4 +67,270 @@ class UIntArrayGeneratorSpec {
             expected.contentEquals(result),
         )
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a UIntArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23.toUInt()
+        val expected = UIntArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a UIntArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toUInt()
+        val expectedMax = 42.toUInt()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        val expected = listOf(
+            23.toUInt(),
+            7.toUInt(),
+            39.toUInt(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toUIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a UIntArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toUInt()
+        val expectedMax = 42.toUInt()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        val expected = listOf(
+            23.toUInt(),
+            7.toUInt(),
+            39.toUInt(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toUIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a UIntArray`() {
+        // Given
+        val expectedMin1 = 0.toUInt()
+        val expectedMax1 = 42.toUInt()
+        val expectedMin2 = 3.toUInt()
+        val expectedMax2 = 41.toUInt()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        val expected = listOf(
+            23.toUInt(),
+            7.toUInt(),
+            39.toUInt(),
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            UIntRange(expectedMin1, expectedMax1),
+            UIntRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toUIntArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a UIntArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0.toUInt()
+        val expectedMax1 = 42.toUInt()
+        val expectedMin2 = 3.toUInt()
+        val expectedMax2 = 41.toUInt()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<UInt, UInt>()
+
+        val expected = listOf(
+            23.toUInt(),
+            7.toUInt(),
+            39.toUInt(),
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = UIntArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            UIntRange(expectedMin1, expectedMax1),
+            UIntRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toUIntArray().contentEquals(result),
+        )
+    }
 }
+
+private data class UIntRange(
+    override val start: UInt,
+    override val endInclusive: UInt,
+) : ClosedRange<UInt>

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.RangedGeneratorStub
 
 class ULongArrayGeneratorSpec {
     private val random = RandomStub()
@@ -31,7 +33,7 @@ class ULongArrayGeneratorSpec {
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = ULongArrayGenerator(random)
+        val generator: Any = ULongArrayGenerator(random, RangedGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
@@ -42,18 +44,19 @@ class ULongArrayGeneratorSpec {
     fun `Given generate is called it returns a ULongArray`() {
         // Given
         val size = 23
-        val expected = ULongArray(size)
-        val generator = ULongArrayGenerator(random)
+        val expectedValue = 23.toULong()
+        val expected = ULongArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
-        val result: ULongArray = generator.generate()
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate()
 
         // Then
         assertEquals(
@@ -64,4 +67,270 @@ class ULongArrayGeneratorSpec {
             expected.contentEquals(result),
         )
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a ULongArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23.toULong()
+        val expected = ULongArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a ULongArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toULong()
+        val expectedMax = 42.toULong()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        val expected = listOf(
+            23.toULong(),
+            7.toULong(),
+            39.toULong(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toULongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a ULongArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toULong()
+        val expectedMax = 42.toULong()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        val expected = listOf(
+            23.toULong(),
+            7.toULong(),
+            39.toULong(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toULongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a ULongArray`() {
+        // Given
+        val expectedMin1 = 0.toULong()
+        val expectedMax1 = 42.toULong()
+        val expectedMin2 = 3.toULong()
+        val expectedMax2 = 41.toULong()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        val expected = listOf(
+            23.toULong(),
+            7.toULong(),
+            39.toULong(),
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            ULongRange(expectedMin1, expectedMax1),
+            ULongRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toULongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a ULongArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0.toULong()
+        val expectedMax1 = 42.toULong()
+        val expectedMin2 = 3.toULong()
+        val expectedMax2 = 41.toULong()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        val expected = listOf(
+            23.toULong(),
+            7.toULong(),
+            39.toULong(),
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            ULongRange(expectedMin1, expectedMax1),
+            ULongRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toULongArray().contentEquals(result),
+        )
+    }
 }
+
+private data class ULongRange(
+    override val start: ULong,
+    override val endInclusive: ULong,
+) : ClosedRange<ULong>


### PR DESCRIPTION
### :pushpin: References
* **Related PRs:** #36

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This migrates the LongArrayGenertator to SignedNumericArrayGenerator and the ULongArrayGenertator to RangedArrayGenerator.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
