### PR TITLE
Change FloatArrayGenerator and DoubleArrayGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - UShortArray
     - UIntArray
     - ULongArray
+    - FloatArray
+    - DoubleArray
 * SignedArrayNumberGenerator for:
     - ByteArray
     - ShortArray

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - UByteArray
     - UShortArray
     - UIntArray
+    - ULongArray
 * SignedArrayNumberGenerator for:
     - ByteArray
     - ShortArray
     - IntArray
+    - LongArray
 * DependentGeneratorFactory in order to build Generators on top of other Generators
 
 ### Changed

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
@@ -60,14 +60,12 @@ internal class Configuration(
             resolveClassName(Char::class) to CharGenerator(random),
             resolveClassName(CharArray::class) to CharArrayGenerator(random),
             resolveClassName(Long::class) to LongGenerator(random),
-            resolveClassName(LongArray::class) to LongArrayGenerator(random),
             resolveClassName(Double::class) to DoubleGenerator(random),
             resolveClassName(DoubleArray::class) to DoubleArrayGenerator(random),
             resolveClassName(String::class) to StringGenerator(random),
             resolveClassName(UShort::class) to UShortGenerator(random),
             resolveClassName(UInt::class) to UIntegerGenerator(random),
             resolveClassName(ULong::class) to ULongGenerator(random),
-            resolveClassName(ULongArray::class) to ULongArrayGenerator(random),
             resolveClassName(UByte::class) to UByteGenerator(random),
             resolveClassName(Any::class) to AnyGenerator,
             resolveClassName(Unit::class) to UnitGenerator,
@@ -112,6 +110,14 @@ internal class Configuration(
             this[resolveClassName(UIntArray::class)] = UIntArrayGenerator(
                 random,
                 this.resolveRangedGenerator(resolveClassName(UInt::class)),
+            )
+            this[resolveClassName(LongArray::class)] = LongArrayGenerator(
+                random,
+                this.resolveSignedGenerator(resolveClassName(Long::class)),
+            )
+            this[resolveClassName(ULongArray::class)] = ULongArrayGenerator(
+                random,
+                this.resolveRangedGenerator(resolveClassName(ULong::class)),
             )
         }
     }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/Configuration.kt
@@ -56,12 +56,10 @@ internal class Configuration(
             resolveClassName(Short::class) to ShortGenerator(random),
             resolveClassName(Int::class) to IntegerGenerator(random),
             resolveClassName(Float::class) to FloatGenerator(random),
-            resolveClassName(FloatArray::class) to FloatArrayGenerator(random),
             resolveClassName(Char::class) to CharGenerator(random),
             resolveClassName(CharArray::class) to CharArrayGenerator(random),
             resolveClassName(Long::class) to LongGenerator(random),
             resolveClassName(Double::class) to DoubleGenerator(random),
-            resolveClassName(DoubleArray::class) to DoubleArrayGenerator(random),
             resolveClassName(String::class) to StringGenerator(random),
             resolveClassName(UShort::class) to UShortGenerator(random),
             resolveClassName(UInt::class) to UIntegerGenerator(random),
@@ -118,6 +116,14 @@ internal class Configuration(
             this[resolveClassName(ULongArray::class)] = ULongArrayGenerator(
                 random,
                 this.resolveRangedGenerator(resolveClassName(ULong::class)),
+            )
+            this[resolveClassName(FloatArray::class)] = FloatArrayGenerator(
+                random,
+                this.resolveRangedGenerator(resolveClassName(Float::class)),
+            )
+            this[resolveClassName(DoubleArray::class)] = DoubleArrayGenerator(
+                random,
+                this.resolveRangedGenerator(resolveClassName(Double::class)),
             )
         }
     }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/DoubleArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/DoubleArrayGenerator.kt
@@ -7,27 +7,14 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class DoubleArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<DoubleArray> {
-    private fun generateDoubleArray(size: Int): DoubleArray {
-        val raw = random.nextBytes(size)
-        val fixture = DoubleArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toInt() + random.nextDouble()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): DoubleArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateDoubleArray(size)
-    }
+    random: Random,
+    doubleGenerator: PublicApi.RangedGenerator<Double, Double>,
+) : RangedArrayNumberGenerator<Double, DoubleArray>(random, doubleGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> Double,
+    ): DoubleArray = DoubleArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/FloatArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/FloatArrayGenerator.kt
@@ -7,27 +7,14 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class FloatArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<FloatArray> {
-    private fun generateFloatArray(size: Int): FloatArray {
-        val raw = random.nextBytes(size)
-        val fixture = FloatArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toInt() + random.nextFloat()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): FloatArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateFloatArray(size)
-    }
+    random: Random,
+    floatGenerator: PublicApi.RangedGenerator<Float, Float>,
+) : RangedArrayNumberGenerator<Float, FloatArray>(random, floatGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> Float,
+    ): FloatArray = FloatArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGenerator.kt
@@ -11,9 +11,9 @@ import tech.antibytes.kfixture.PublicApi
 
 internal class LongArrayGenerator(
     random: Random,
-    shortGenerator: PublicApi.SignedNumberGenerator<Long, Long>,
+    longGenerator: PublicApi.SignedNumberGenerator<Long, Long>,
 ) : PublicApi.SignedNumericArrayGenerator<Long, LongArray>,
-    SignedArrayNumberGenerator<Long, LongArray>(random, shortGenerator) {
+    SignedArrayNumberGenerator<Long, LongArray>(random, longGenerator) {
     override fun arrayBuilder(
         size: Int,
         onEach: (idx: Int) -> Long,

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGenerator.kt
@@ -7,27 +7,15 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class LongArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<LongArray> {
-    private fun generateLongArray(size: Int): LongArray {
-        val raw = random.nextBytes(size)
-        val fixture = LongArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toLong()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): LongArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateLongArray(size)
-    }
+    random: Random,
+    shortGenerator: PublicApi.SignedNumberGenerator<Long, Long>,
+) : PublicApi.SignedNumericArrayGenerator<Long, LongArray>,
+    SignedArrayNumberGenerator<Long, LongArray>(random, shortGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> Long,
+    ): LongArray = LongArray(size, onEach)
 }

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGenerator.kt
@@ -11,8 +11,8 @@ import tech.antibytes.kfixture.PublicApi
 
 internal class UIntArrayGenerator(
     random: Random,
-    uShortGenerator: PublicApi.RangedGenerator<UInt, UInt>,
-) : RangedArrayNumberGenerator<UInt, UIntArray>(random, uShortGenerator) {
+    uIntGenerator: PublicApi.RangedGenerator<UInt, UInt>,
+) : RangedArrayNumberGenerator<UInt, UIntArray>(random, uIntGenerator) {
     override fun arrayBuilder(
         size: Int,
         onEach: (idx: Int) -> UInt,

--- a/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGenerator.kt
+++ b/core/src/commonMain/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGenerator.kt
@@ -7,28 +7,14 @@
 package tech.antibytes.kfixture.generator.array
 
 import kotlin.random.Random
-import kotlin.random.nextUBytes
-import tech.antibytes.kfixture.FixtureContract.ARRAY_LOWER_BOUND
-import tech.antibytes.kfixture.FixtureContract.ARRAY_UPPER_BOUND
 import tech.antibytes.kfixture.PublicApi
 
 internal class ULongArrayGenerator(
-    private val random: Random,
-) : PublicApi.Generator<ULongArray> {
-    private fun generateULongArray(size: Int): ULongArray {
-        val raw = random.nextUBytes(size)
-        val fixture = ULongArray(size)
-
-        repeat(size) { idx ->
-            fixture[idx] = raw[idx].toULong()
-        }
-
-        return fixture
-    }
-
-    override fun generate(): ULongArray {
-        val size = random.nextInt(ARRAY_LOWER_BOUND, ARRAY_UPPER_BOUND)
-
-        return generateULongArray(size)
-    }
+    random: Random,
+    uLongGenerator: PublicApi.RangedGenerator<ULong, ULong>,
+) : RangedArrayNumberGenerator<ULong, ULongArray>(random, uLongGenerator) {
+    override fun arrayBuilder(
+        size: Int,
+        onEach: (idx: Int) -> ULong,
+    ): ULongArray = ULongArray(size, onEach)
 }

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ByteArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ByteArrayGeneratorSpec.kt
@@ -32,10 +32,10 @@ class ByteArrayGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils SignedNumericArrayGenerator`() {
         val generator: Any = ByteArrayGenerator(random, SignedNumberGeneratorStub())
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.SignedNumericArrayGenerator<*, *>)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/IntArrayGeneratorSpec.kt
@@ -32,10 +32,10 @@ class IntArrayGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils SignedNumericArrayGenerator`() {
         val generator: Any = IntArrayGenerator(random, SignedNumberGeneratorStub())
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.SignedNumericArrayGenerator<*, *>)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGeneratorSpec.kt
@@ -32,10 +32,10 @@ class LongArrayGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils SignedNumericArrayGenerator`() {
         val generator: Any = LongArrayGenerator(random, SignedNumberGeneratorStub())
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.SignedNumericArrayGenerator<*, *>)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/LongArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.SignedNumberGeneratorStub
 
 class LongArrayGeneratorSpec {
     private val random = RandomStub()
@@ -31,7 +33,7 @@ class LongArrayGeneratorSpec {
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = LongArrayGenerator(random)
+        val generator: Any = LongArrayGenerator(random, SignedNumberGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
@@ -42,18 +44,19 @@ class LongArrayGeneratorSpec {
     fun `Given generate is called it returns a LongArray`() {
         // Given
         val size = 23
-        val expected = LongArray(size)
-        val generator = LongArrayGenerator(random)
+        val expectedValue = 23.toLong()
+        val expected = LongArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
-        val result: LongArray = generator.generate()
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate()
 
         // Then
         assertEquals(
@@ -64,4 +67,348 @@ class LongArrayGeneratorSpec {
             expected.contentEquals(result),
         )
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a LongArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23.toLong()
+        val expected = LongArray(size) { expectedValue }
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a LongArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toLong()
+        val expectedMax = 42.toLong()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expected = listOf(
+            23.toLong(),
+            7.toLong(),
+            39.toLong(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toLongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a LongArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toLong()
+        val expectedMax = 42.toLong()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expected = listOf(
+            23.toLong(),
+            7.toLong(),
+            39.toLong(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toLongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a LongArray`() {
+        // Given
+        val expectedMin1 = 0.toLong()
+        val expectedMax1 = 42.toLong()
+        val expectedMin2 = 3.toLong()
+        val expectedMax2 = 41.toLong()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expected = listOf(
+            23.toLong(),
+            7.toLong(),
+            39.toLong(),
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            LongRange(expectedMin1, expectedMax1),
+            LongRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toLongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a LongArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0.toLong()
+        val expectedMax1 = 42.toLong()
+        val expectedMin2 = 3.toLong()
+        val expectedMax2 = 41.toLong()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expected = listOf(
+            23.toLong(),
+            7.toLong(),
+            39.toLong(),
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            LongRange(expectedMin1, expectedMax1),
+            LongRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toLongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn7")
+    fun `Given generate is called with a Sign it returns a LongArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expectedValue = 42.toLong()
+        val expected = LongArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn8")
+    fun `Given generate is called with a Sign and Size it returns a LongArray`() {
+        // Given
+        val expectedSign = PublicApi.Sign.NEGATIVE
+        val size = 23
+
+        var capturedSign: PublicApi.Sign? = null
+
+        val auxiliaryGenerator = SignedNumberGeneratorStub<Long, Long>()
+
+        val expectedValue = 42.toLong()
+        val expected = LongArray(size) { expectedValue }
+
+        auxiliaryGenerator.generateWithSign = { givenSign ->
+            capturedSign = givenSign
+
+            expectedValue
+        }
+
+        // When
+        val generator = LongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(expectedSign, size)
+
+        // Then
+        assertEquals(
+            actual = capturedSign,
+            expected = expectedSign,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
 }
+
+private data class LongRange(
+    override val start: Long,
+    override val endInclusive: Long,
+) : ClosedRange<Long>

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ShortArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ShortArrayGeneratorSpec.kt
@@ -32,10 +32,10 @@ class ShortArrayGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils SignedNumericArrayGenerator`() {
         val generator: Any = ShortArrayGenerator(random, SignedNumberGeneratorStub())
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.SignedNumericArrayGenerator<*, *>)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UByteArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UByteArrayGeneratorSpec.kt
@@ -32,10 +32,10 @@ class UByteArrayGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils RangedArrayGenerator`() {
         val generator: Any = UByteArrayGenerator(random, RangedGeneratorStub())
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.RangedArrayGenerator<*, *>)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UIntArrayGeneratorSpec.kt
@@ -32,10 +32,10 @@ class UIntArrayGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils RangedArrayGenerator`() {
         val generator: Any = UIntArrayGenerator(random, RangedGeneratorStub())
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.RangedArrayGenerator<*, *>)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGeneratorSpec.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kfixture.generator.array
 
+import co.touchlab.stately.collections.sharedMutableListOf
 import kotlin.js.JsName
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -16,6 +17,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import tech.antibytes.kfixture.PublicApi
 import tech.antibytes.kfixture.mock.RandomStub
+import tech.antibytes.kfixture.mock.RangedGeneratorStub
 
 class ULongArrayGeneratorSpec {
     private val random = RandomStub()
@@ -31,7 +33,7 @@ class ULongArrayGeneratorSpec {
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
     fun `It fulfils Generator`() {
-        val generator: Any = ULongArrayGenerator(random)
+        val generator: Any = ULongArrayGenerator(random, RangedGeneratorStub())
 
         assertTrue(generator is PublicApi.Generator<*>)
     }
@@ -42,18 +44,19 @@ class ULongArrayGeneratorSpec {
     fun `Given generate is called it returns a ULongArray`() {
         // Given
         val size = 23
-        val expected = ULongArray(size)
-        val generator = ULongArrayGenerator(random)
+        val expectedValue = 23.toULong()
+        val expected = ULongArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
 
+        auxiliaryGenerator.generate = { expectedValue }
         random.nextIntRanged = { from, to ->
             range.update { Pair(from, to) }
             size
         }
 
-        random.nextBytesArray = { arraySize -> ByteArray(arraySize) }
-
         // When
-        val result: ULongArray = generator.generate()
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate()
 
         // Then
         assertEquals(
@@ -64,4 +67,270 @@ class ULongArrayGeneratorSpec {
             expected.contentEquals(result),
         )
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn2")
+    fun `Given generate is called with a size it returns a ULongArray in the given size`() {
+        // Given
+        val size = 12
+        val expectedValue = 23.toULong()
+        val expected = ULongArray(size) { expectedValue }
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        auxiliaryGenerator.generate = { expectedValue }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(size)
+
+        // Then
+        assertEquals(
+            actual = result.size,
+            expected = size,
+        )
+        assertTrue(
+            expected.contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn3")
+    fun `Given generate is called with boundaries it returns a ULongArray`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toULong()
+        val expectedMax = 42.toULong()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        val expected = listOf(
+            23.toULong(),
+            7.toULong(),
+            39.toULong(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            size
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax)
+
+        // Then
+        assertEquals(
+            actual = Pair(1, 10),
+            expected = range.value,
+        )
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toULongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn4")
+    fun `Given generate is called with boundaries it returns a ULongArray with a given Size`() {
+        // Given
+        val size = 3
+        val expectedMin = 0.toULong()
+        val expectedMax = 42.toULong()
+
+        var capturedMin: Int? = null
+        var capturedMax: Int? = null
+
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        val expected = listOf(
+            23.toULong(),
+            7.toULong(),
+            39.toULong(),
+        )
+        val consumableItem = expected.toSharedMutableList()
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin = givenMin.toInt()
+            capturedMax = givenMax.toInt()
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(from = expectedMin, to = expectedMax, size = size)
+
+        // Then
+        assertEquals(
+            actual = capturedMin,
+            expected = expectedMin.toInt(),
+        )
+        assertEquals(
+            actual = capturedMax,
+            expected = expectedMax.toInt(),
+        )
+        assertTrue(
+            expected.toULongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn5")
+    fun `Given generate is called with ranges it returns a ULongArray`() {
+        // Given
+        val expectedMin1 = 0.toULong()
+        val expectedMax1 = 42.toULong()
+        val expectedMin2 = 3.toULong()
+        val expectedMax2 = 41.toULong()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        val expected = listOf(
+            23.toULong(),
+            7.toULong(),
+            39.toULong(),
+        )
+        val ranges = sharedMutableListOf(3, 1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            ULongRange(expectedMin1, expectedMax1),
+            ULongRange(expectedMin2, expectedMax2),
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toULongArray().contentEquals(result),
+        )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    @JsName("fn6")
+    fun `Given generate is called with ranges it returns a ULongArray with a given Size`() {
+        // Given
+        val expectedSize = 3
+        val expectedMin1 = 0.toULong()
+        val expectedMax1 = 42.toULong()
+        val expectedMin2 = 3.toULong()
+        val expectedMax2 = 41.toULong()
+
+        val capturedMin: MutableList<Int> = sharedMutableListOf()
+        val capturedMax: MutableList<Int> = sharedMutableListOf()
+
+        val auxiliaryGenerator = RangedGeneratorStub<ULong, ULong>()
+
+        val expected = listOf(
+            23.toULong(),
+            7.toULong(),
+            39.toULong(),
+        )
+        val ranges = sharedMutableListOf(1, 0, 1)
+
+        val consumableItem = expected.toSharedMutableList()
+
+        random.nextIntRanged = { from, to ->
+            range.update { Pair(from, to) }
+            ranges.removeFirst()
+        }
+
+        auxiliaryGenerator.generateWithRange = { givenMin, givenMax ->
+            capturedMin.add(givenMin.toInt())
+            capturedMax.add(givenMax.toInt())
+
+            consumableItem.removeFirst()
+        }
+
+        // When
+        val generator = ULongArrayGenerator(random, auxiliaryGenerator)
+        val result = generator.generate(
+            ULongRange(expectedMin1, expectedMax1),
+            ULongRange(expectedMin2, expectedMax2),
+            size = expectedSize,
+        )
+
+        // Then
+        assertEquals(
+            actual = range.value,
+            expected = Pair(1, 2),
+        )
+        assertTrue(
+            actual = expectedMin1.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMin2.toInt() in capturedMin,
+        )
+        assertTrue(
+            actual = expectedMax1.toInt() in capturedMax,
+        )
+        assertTrue(
+            actual = expectedMax2.toInt() in capturedMax,
+        )
+
+        assertTrue(
+            expected.toULongArray().contentEquals(result),
+        )
+    }
 }
+
+private data class ULongRange(
+    override val start: ULong,
+    override val endInclusive: ULong,
+) : ClosedRange<ULong>

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/ULongArrayGeneratorSpec.kt
@@ -32,10 +32,10 @@ class ULongArrayGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils RangedArrayGenerator`() {
         val generator: Any = ULongArrayGenerator(random, RangedGeneratorStub())
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.RangedArrayGenerator<*, *>)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UShortArrayGeneratorSpec.kt
+++ b/core/src/commonTest/kotlin/tech/antibytes/kfixture/generator/array/UShortArrayGeneratorSpec.kt
@@ -32,10 +32,10 @@ class UShortArrayGeneratorSpec {
     @Test
     @Suppress("UNCHECKED_CAST")
     @JsName("fn0")
-    fun `It fulfils Generator`() {
+    fun `It fulfils RangedArrayGenerator`() {
         val generator: Any = UShortArrayGenerator(random, RangedGeneratorStub())
 
-        assertTrue(generator is PublicApi.Generator<*>)
+        assertTrue(generator is PublicApi.RangedArrayGenerator<*, *>)
     }
 
     @Test


### PR DESCRIPTION
### :pushpin: References
* **Related PRs:** #36

### What does the PR achieve/Which part improves the PR?
This migrates the FloatArrayGenertator and the DoubleArrayGenertator to RangedArrayGenerator.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
